### PR TITLE
Mom's Tent - Dissolve fixes and new letter code

### DIFF
--- a/src/s2a_moms_tent.tw2
+++ b/src/s2a_moms_tent.tw2
@@ -8,13 +8,13 @@
 ::Mom's Tent - intro
 [(live: 2s)[(if: time > 2s)[$dissolve[I stumbled along the old familiar path toward Mom’s tent. My feet moved clumsily under me — I was still feeling fucked up.(stop:)]]]]
 
-(click: "fucked up") [(transition: "dissolve")[My head was spinning: why did Anna lock me up? No, that’s not even it; more like, why the hell would she ever do something like that? It doesn’t make any sense. She’s like my sister. Isn’t she?]]
+(click: "fucked up") [$dissolve[My head was spinning: why did Anna lock me up? No, that’s not even it; more like, why the hell would she ever do something like that? It doesn’t make any sense. She’s like my sister. Isn’t she?]]
 
-(click: "make any sense") [(transition: "dissolve")[I shook my head, trying to find the correct order for the thoughts circling in my brain. I needed to get my shit together.]]
+(click: "make any sense") [$dissolve[I shook my head, trying to find the correct order for the thoughts circling in my brain. I needed to get my shit together.]]
 
-(click: "get my shit together") [(transition: "dissolve")[I looked up, and suddently there it was:]]
+(click: "get my shit together") [$dissolve[I looked up, and suddently there it was:]]
 
-(click: "there it was") [(transition: "dissolve")[a smattering of tarps nailed onto a rickety-ass wooden frame,]]
+(click: "there it was") [$dissolve[a smattering of tarps nailed onto a rickety-ass wooden frame,]]
 
 (click: "rickety-ass wooden frame") [(transition: "dissolve")[<span style="padding-left:2em">extension cables snaking from a lamppost and disappearing under the floorboards,</span>]]
 
@@ -37,11 +37,11 @@ But it was clear Mom and Ron had been up to their usual bullshit recently: a fre
 ::Mom's Tent - den 2
 I froze in place and listened intently.
 
-(click: "listened intently") [(transition: "dissolve") +(transition-time: 1s)[No noises. Just the tarp walls flapping in the evening breeze.]]
+(click: "listened intently") [$dissolve[No noises. Just the tarp walls flapping in the evening breeze.]]
 
-(click: "No noises") [(transition: "dissolve")[I was alone, praise the fucking lord.]]
+(click: "No noises") [$dissolve[I was alone, praise the fucking lord.]]
 
-(click: "praise the fucking lord") [(transition: "dissolve")[I walked over to the fridge a few feet away and scanned the shelves. Nothing much left — just half a ham sandwich on a paper plate, a twelve-pack of [[sodas|Mom's Tent - faygo]] and a lone [[can of beer|Mom's Tent - beer]].]]
+(click: "praise the fucking lord") [$dissolve[I walked over to the fridge a few feet away and scanned the shelves. Nothing much left — just half a ham sandwich on a paper plate, a twelve-pack of [[sodas|Mom's Tent - faygo]] and a lone [[can of beer|Mom's Tent - beer]].]]
 
 ::Mom's Tent - faygo
 Ah, Redpop. Anna and I had this weirdo friend, Scott, who went absolutely bonkers for this shit. He loved to get turned wayyyy up on the sugar rush and rave about how delicious it was to drink “the blood of the innocent.”
@@ -116,7 +116,7 @@ It was a to-do list. No real surprises there:
 * Patch ripped wall in L.R.
 * Talk to Ron about budget (<u>no more</u> wasting money at The Gutter!!)
 And sure enough, there was a line item for me. It read:
-* <i>Talk to $playerName about the house rules — NO MORE SNEAKING OFF WITH ANNA AFTER DARK!</i>
+* //Talk to $playerName about the house rules — NO MORE SNEAKING OFF WITH ANNA AFTER DARK!//
 Great. The one time I disappear without a trace, she’s somehow [[sober enough to notice|Mom's Tent - table hub]].(stop:)]]]]
 
 ::Mom's Tent - support beam
@@ -203,82 +203,41 @@ I couldn’t just leave. I needed to at least let her know what’s up.
 
 I turned back to my desk, picked up a pencil, and began to write:
 
-(link: "Hey,")[(set: $letterHey to true)(go-to: "Mom's Tent - letter to mom 2")]
-[[Hey Mom,|Mom's Tent - letter to mom 2]]
-
+<div style="padding-left: 2em; font-style: italic;">
+\[Hey,]<momLetter1a|(click: ?momLetter1a)[(replace: ?momLetter1b)[](display: "Mom's Tent - letter to mom 2")]
+[Hey Mom,]<momLetter1b|(click: ?momLetter1b)[(replace: ?momLetter1a)[](display: "Mom's Tent - letter to mom 2")]
+</div>
 ::Mom's Tent - letter to mom 2
-(if: $letterHey is true)[Hey,](else:)[Hey Mom,]
-
-(link:"I’m sorry I didn’t make it home last night. Things are messed up, but it’s not my fault.")[(set: $letterApology to true)(go-to: "Mom's Tent - letter to mom 3")]
-[[I came home to get some rest, but it turns out my bed was occupied. Thanks a lot.|Mom's Tent - letter to mom 3]]
+[<br><br>I’m sorry I didn’t make it home last night. Things are messed up, but it’s not my fault.]<momLetter2a|(click: ?momLetter2a)[(replace: ?momLetter2b)[](display: "Mom's Tent - letter to mom 3")]
+[<br>I came home to get some rest, but it turns out my bed was occupied. Thanks a lot.]<momLetter2b|(click: ?momLetter2b)[(replace: ?momLetter2a)[](display: "Mom's Tent - letter to mom 3")]
 
 ::Mom's Tent - letter to mom 3
-(if: $letterHey is true)[Hey](else:)[Hey Mom,]
-
-(if: $letterApology is true)[I’m sorry I didn’t make it home last night. Things are messed up, but it’s not my fault.](else:)[I came home to get some rest, but it turns out my bed was occupied. Thanks a lot.]
-
-(link:"I’m worried about Anna. She straight-up disappeared on me last night. It’s not like her at all. I’m worried shit’s gone way wrong for her.")[(set: $letterWorried to true)(go-to: "Mom's Tent - letter to mom 4")]
-[[I just dropped by to get some of my stuff.|Mom's Tent - letter to mom 4]]
+[<br><br>I’m worried about Anna. She straight-up disappeared on me last night. It’s not like her at all. I’m worried shit’s gone way wrong for her.]<momLetter3a|(click: ?momLetter3a)[(replace: ?momLetter3b)[](display: "Mom's Tent - letter to mom 4")]
+[<br>I just dropped by to get some of my stuff.]<momLetter3b|(click: ?momLetter3b)[(replace: ?momLetter3a)[](display: "Mom's Tent - letter to mom 4")]
 
 ::Mom's Tent - letter to mom 4
-(if: $letterHey is true)[Hey](else:)[Hey Mom,]
-
-(if: $letterApology is true)[I’m sorry I didn’t make it home last night. Things are messed up, but it’s not my fault.](else:)[I came home to get some rest, but it turns out my bed was occupied. Thanks a lot.]
-
-(if: $letterWorried is true)[I’m worried about Anna. She straight-up disappeared on me last night. It’s not like her at all. I’m worried shit’s gone way wrong for her.](else:)[I just dropped by to get some of my stuff.]
-
-(link:"I know Anna’s in trouble, and I’ve gotta make sure she’s ok.")[(set: $letterTrouble to true)(go-to: "Mom's Tent - letter to mom 5")]
-(if: $beerDrank is true)[[[I drank some of Ron’s Milenkale. Be sure to let him know it was me|Mom's Tent - letter to mom 5]].](else:)[>>[[I drank some of Ron’s Faygo. Be sure to let him know it was me|Mom's Tent - letter to mom 5]].]
+[<br><br>I know Anna’s in trouble, and I’ve gotta make sure she’s ok.]<momLetter4a|(click: ?momLetter4a)[(replace: ?momLetter4b)[](display: "Mom's Tent - letter to mom 5")]
+[<br>I drank some of Ron’s (if: $beerDrank is true)[Milenkale](else:)[Faygo]. Be sure to let him know it was me.]<momLetter4b|(click: ?momLetter4b)[(replace: ?momLetter4a)[](display: "Mom's Tent - letter to mom 5")]
 
 ::Mom's Tent - letter to mom 5
-(if: $letterHey is true)[Hey](else:)[Hey Mom,]
-
-(if: $letterApology is true)[I’m sorry I didn’t make it home last night. Things are messed up, but it’s not my fault.](else:)[I came home to get some rest, but it turns out my bed was occupied. Thanks a lot.]
-
-(if: $letterWorried is true)[I’m worried about Anna. She straight-up disappeared on me last night. It’s not like her at all. I’m worried shit’s gone way wrong for her.](else:)[I just dropped by to get some of my stuff.]
-
-(if: $letterTrouble is true)[I know Anna’s in trouble, and I’ve gotta make sure she’s ok.](else:)[I drank some of Ron’s (if: $beerDrank is true)[Milenkale](else:)[Faygo]. Be sure to let him know it was me.]
-
-(link:"I don’t know what’s going to happen, but I’ll be back as soon as I can be.")[(set: $letterBackSoon to true)(go-to: "Mom's Tent - letter to mom 6")]
-[[I hope you’ve kicked that asshole to the curb by the time I’m back. You deserve so much better than him.|Mom's Tent - letter to mom 6]]
+[<br><br>I don’t know what’s going to happen, but I’ll be back as soon as I can be.]<momLetter5a|(click: ?momLetter5a)[(replace: ?momLetter5b)[](display: "Mom's Tent - letter to mom 6")]
+[<br>I hope you’ve kicked that asshole to the curb by the time I’m back. You deserve so much better than him.]<momLetter5b|(click: ?momLetter5b)[(replace: ?momLetter5a)[](display: "Mom's Tent - letter to mom 6")]
 
 ::Mom's Tent - letter to mom 6
-(if: $letterHey is true)[Hey](else:)[Hey Mom,]
+[<br><br>Love you,]<momLetter6a|(click: ?momLetter6a)[(replace: ?momLetter6b)[](display: "Mom's Tent - letter mom end")]
+[<br>Smell ya later,]<momLetter6b|(click: ?momLetter6b)[(replace: ?momLetter6a)[](display: "Mom's Tent - letter mom end")]
 
-(if: $letterApology is true)[I’m sorry I didn’t make it home last night. Things are messed up, but it’s not my fault.](else:)[I came home to get some rest, but it turns out my bed was occupied. Thanks a lot.]
-
-(if: $letterWorried is true)[I’m worried about Anna. She straight-up disappeared on me last night. It’s not like her at all. I’m worried shit’s gone way wrong for her.](else:)[I just dropped by to get some of my stuff.]
-
-(if: $letterTrouble is true)[I know she’s in trouble, and I’ve gotta make sure she’s ok.](else:)[I drank some of Ron’s (if: $beerDrank is true)[Milenkale](else:)[Faygo]. Be sure to let him know it was me.]
-
-(if: $letterBackSoon is true)[I don’t know what’s going to happen, but I’ll be back as soon as I can be.](else:)[I hope you’ve kicked that asshole to the curb by the time I’m back. You deserve so much better than him.]
-
-(link:"Love you,")[(set: $letterLove to true)(go-to: "Mom's Tent - letter to mom end")]
-[[Smell ya later,|Mom's Tent - letter to mom end]]
-
-::Mom's Tent - letter to mom end
-(if: $letterHey is true)[Hey](else:)[Hey Mom,]
-
-(if: $letterApology is true)[I’m sorry I didn’t make it home last night. Things are messed up, but it’s not my fault.](else:)[I came home to get some rest, but it turns out my bed was occupied. Thanks a lot.]
-
-(if: $letterWorried is true)[I’m worried about Anna. She straight-up disappeared on me last night. It’s not like her at all. I’m worried shit’s gone way wrong for her.](else:)[I just dropped by to get some of my stuff.]
-
-(if: $letterTrouble is true)[I know she’s in trouble, and I’ve gotta make sure she’s ok.](else:)[I drank some of Ron’s (if: $beerDrank is true)[Milenkale](else:)[Faygo]. Be sure to let him know it was me.]
-
-(if: $letterBackSoon is true)[I don’t know what’s going to happen, but I’ll be back as soon as I can be.](else:)[I hope you’ve kicked that asshole to the curb by the time I’m back. You deserve so much better than him.]
-
-(if: $letterLove is true)[Love you,](else:)[Smell ya later,]
-
-<span style="padding-left:2em">[[**$playerName**|Mom's Tent - Leo enters]]</span>
+::Mom's Tent - letter mom end
+[[<br>**$playerName**|Mom's Tent - Leo enters]]
 
 ::Mom's Tent - Leo enters
 There. Good enough. I set the pencil down, shifted my bag onto my shoulders, and got up to leave —
 
 And I heard something that made my heart nearly pop out of my chest.
 
-(click: "something that made my heart nearly pop out of my chest")[(transition: "dissolve")["Hey, $playerName! Heard you turned up again, girl. Don’t you wanna come out and see your main man?"]]
+[(live: 1s)[(if: time > 5s)[$dissolve["Hey, $playerName! Heard you turned up again, girl. Don’t you wanna come out and see your main man?"(stop:)]]]]
 
-(click: "your main man")[Fuck.]
+[(live: 1s)[(if: time > 7s)[$dissolve[Fuck.(stop:)]]]]
 
 (click: "Fuck")[Leo.]
 
@@ -301,6 +260,6 @@ Fuck. As soon as I gripped the (if: $multitool is true)[tool](else:)[hatchet's h
 
 No time to waste. I slashed at the rear tarp, ripping a gnarly hole right through the wall of my room. Loud enough to wake the dead.
 
-(click: "wake the dead")[Mom sat up suddenly, blinked heavily. “$playerName?” she yelped.]
+(click: "wake the dead")[$dissolve[Mom sat up suddenly, blinked heavily. “$playerName?” she yelped.]]
 
-(click: "she yelped")[But I was through, and my feet were moving, thumping hard against the gravel and dirt paths, weaving between the tents, panic stabbing at my brain, no time to think, and I was [[gone, gone, gone|Tent City - Intro]].]
+(click: "she yelped")[$dissolve[But I was through, and my feet were moving, thumping hard against the gravel and dirt paths, weaving between the tents, panic stabbing at my brain, no time to think, and I was [[gone, gone, gone|Tent City - Intro]].]]

--- a/src/s2a_moms_tent.tw2
+++ b/src/s2a_moms_tent.tw2
@@ -111,13 +111,13 @@ Mom loves to keep notes. She writes down all kinds of things — keeps track of 
 (set: $tableDetailsSeen to it +1)
 
 ::Mom's Tent - notepad 2
-It was a to-do list. No real surprises there:
-- REMEMBER: working extra shifts for Jolene next Sat. & Sun.
+It was a [to-do list]<listTrigger|. No real surprises there:
+(click: ?listTrigger)[$dissolve[<div style="padding-left: 2em;">- REMEMBER: working extra shifts for Jolene next Sat. & Sun.
 - Patch ripped wall in L.R.
-- Talk to Ron about budget (<u>no more</u> wasting money at The Gutter!!)
-And sure enough, there was a line item for me. It read:
-- //Talk to $playerName about the house rules — NO MORE SNEAKING OFF WITH ANNA AFTER DARK!//
-Great. The one time I disappear without a trace, she’s somehow [[sober enough to notice|Mom's Tent - table hub]].
+- Talk to Ron about budget – no more [wasting money at The Gutter]<listTrigger2|!!</div>]]
+(click: ?listTrigger2)[$dissolve[And sure enough, there was [a line item for me]<listTrigger3|. It read:]]
+(click: ?listTrigger3)[$dissolve[<div style="padding-left: 2em;">- //Talk to $playerName about the house rules — NO MORE [SNEAKING OFF WITH ANNA]<listTrigger4| AFTER DARK!//</div>]]
+(click: ?listTrigger4)[$dissolve[Great. The one time I disappear without a trace, she’s somehow [[sober enough to notice|Mom's Tent - table hub]].]]
 
 ::Mom's Tent - support beam
 The support beam separating the kitchen from my tent was looking pretty funky, but it was still standing. I scanned from the bottom up, watching the series of notches and dates go by:


### PR DESCRIPTION
These are changes from #42. Here's what I did:
* Added $dissolve anywhere the code was doing the transition manually, so that time is standard. I didn't add this in any place we want to go slower or faster (snoring, Leo's appearance)
* Rewrote the letter to mom section with Nathan's code from the wrestling match. It looks really cool! I'd encourage you to check it out when testing. I really like it, and it lets the player create a letter styled like other letters in the game in one passage, but I'm open to feedback.
* Decided to ditch the idea about mentioning rations
* Tried to fix the pop-in on the bulleted list in Chrome by wrapping each set of bullets and text in live: macros. This created even more weird pop-in and made Harlowe pop an error. 🙃 I think we should just leave it or find another, safer way to present the list.