### PR TITLE
Fix padding on smaller screens and mobile devices

### DIFF
--- a/src/css.tw2
+++ b/src/css.tw2
@@ -12,6 +12,11 @@ tw-link.visited {
   color: rgb(65, 105, 225);
 }
 
+tw-link:hover,
+tw-link.visited:hover {
+  color: #00bfff;
+}
+
 img {
   max-height: 60vh;
 }

--- a/src/css.tw2
+++ b/src/css.tw2
@@ -1,9 +1,10 @@
 ::Stylesheet [stylesheet]
 @import url('https://fonts.googleapis.com/css?family=VT323');
 
-tw-story {
-  /* Override default container styles here */
-  /* padding: 30px 40px 30px 140px; */
+@media screen and (max-width: 1000px) {
+  tw-story {
+    padding: 10% 10% 5% 20%;
+  }
 }
 
 tw-link,


### PR DESCRIPTION
![screen shot 2018-08-30 at 9 02 30 pm](https://user-images.githubusercontent.com/4277237/44892169-19a43b00-ac98-11e8-930a-1a2d332e2732.png)

Fixes and shrinks the padding on mobile devices to avoid a weirdly cropped/tiny/centered text effect on phones.