### PR TITLE
Remove repeated 20XX year refs in Mom's Tent

### DIFF
--- a/src/s2a_moms_tent.tw2
+++ b/src/s2a_moms_tent.tw2
@@ -122,25 +122,25 @@ It was a [to-do list]<listTrigger|. No real surprises there:
 ::Mom's Tent - support beam
 The support beam separating the kitchen from my tent was looking pretty funky, but it was still standing. I scanned from the bottom up, watching the series of notches and dates go by:
 
-|RON 69/666
+|RON 69 420 666 years
 |
 |
 |
 |
 |
-|$playerName 7/20XX
+|$playerName 12 years
 |
 |
 |
-|$playerName 13/20XX
+|$playerName 10 years
 |
 |
-|$playerName 9/20XX
+|$playerName 7 years
 |
-|$playerName 3/20XX
+|$playerName 5 years
 |
 |
-|$playerName 2/20XX
+|$playerName 3 years
 
 From looking around the scene, it’s the only proof I ever lived here.
 


### PR DESCRIPTION
Based on player feedback, let's remove some of the most repetitive 20XX usage.