### PR TITLE
Added email address to credits

### DIFF
--- a/src/efjm.tw2
+++ b/src/efjm.tw2
@@ -54,6 +54,8 @@ Yelena Kolova and Dan Phipps
 - Sean Dunne
 - Nathan Rabin
 
+**Bugs or press?**
+escapefromjuggalomountain@gmail.com
 
 [[back to main menu|Title Screen]]
 


### PR DESCRIPTION
Our email address, escapefromjuggalomountain@gmail.com, is now in the credits for press contact and bug reporting.